### PR TITLE
Use string as modeline lighter format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ dhall executable:
 (reformatter-define dhall-format
   :program dhall-command
   :args '("format")
-  :lighter 'DF)
+  :lighter " DF")
 ```
 
 The `reformatter-define` macro expands to code which generates


### PR DESCRIPTION
Since this is the recommened (only supported?) approach since
6484d45a87d01e3ab88c527cf7a7b209ddd713bf