### PR TITLE
fix #25 hook for post-processing formatter output

### DIFF
--- a/reformatter.el
+++ b/reformatter.el
@@ -229,7 +229,7 @@ OUTPUT-PROCESSOR
   If provided, this is a function that takes the output PROGRAM,
   do some arbitrary processing to it, and then return the final
   output.  If not supplied, the output is returned as is."
-  (declare (indent defun))
+  (declare (indent defun) (debug (name :program :args :mode :group :lighter :keymap :exit-code-success-p :output-post-processor)))
   (cl-assert (symbolp name))
   (cl-assert (functionp exit-code-success-p))
   (cl-assert (functionp output-processor))


### PR DESCRIPTION
This enables eslint to work with reformatter using the following configuration:

```elisp
(reformatter-define eslint-format
    :program "eslint"
    :args `("--fix-dry-run"
            "--format"
            "json"
            "--stdin"
            "--stdin-filename"
            ,buffer-file-name
            "--ext"
            ".json,.js,.jsx,.mjs,.mjsx,.cjs,.cjsx,.ts,.tsx")
    :output-processor (lambda (file)
                        (let* ((data (json-read-file file))
                               (output (alist-get 'output (aref data 0))))
                          (make-temp-file "eslint-format" nil nil output)))
    :exit-code-success-p integerp)
```